### PR TITLE
Add CRUD APIs and basic betting UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+.env
+*.tfstate
+*.tfstate.*
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
 # svm-projections
+
+This repository contains a simple layered web application with a Vue.js frontend and a FastAPI backend.
+
+## Structure
+
+- `frontend/` – minimal Vue application
+- `backend/` – FastAPI service exposing Firestore based APIs with full CRUD endpoints
+
+## Development
+
+1. Install Python dependencies and run the backend:
+   ```bash
+   cd backend
+   pip install -r requirements.txt
+   uvicorn src.main:app --reload
+   ```
+
+2. Open `frontend/index.html` in your browser during local development.
+
+The frontend uses Firebase Authentication. Update the configuration in
+`frontend/index.html` with your Firebase project credentials.
+
+Once logged in you can select a team and see the odds against the other clubs.
+Submitting the form will create a bet in Firestore.
+
+## Deployment
+
+Terraform configuration is provided in the `infra/` directory. Copy
+`terraform.tfvars.example` to `terraform.tfvars` and update the values for your
+Google Cloud project and container image. Initialize and apply the configuration
+to create a Cloud Run service:
+
+```bash
+cd infra
+terraform init
+terraform apply
+```
+
+The repository also contains a `cloudbuild.yaml` file which you can trigger with
+Google Cloud Build to build and push the backend image referenced by the
+Terraform configuration.

--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -1,0 +1,2 @@
+FIREBASE_PROJECT_ID=your-gcp-project
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/serviceAccount.json

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY ./src ./src
+CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,24 +1,26 @@
-backend/
-├── Dockerfile
-├── requirements.txt
-├── .env.sample            # template for all envs
-├── .env.dev               # dev environment variables
-├── .env.prod              # prod environment variables
-└── src/
-    ├── main.py
-    ├── config.py          # environment-specific config loader
-    ├── db.py              # initialize Firestore using config
-    ├── services/
-    │   ├── firestore.py
-    │   └── auth.py
-    ├── schemas/
-    │   ├── user.py
-    │   ├── event.py
-    │   ├── bet.py
-    │   └── odds.py
-    └── routes/
-        ├── __init__.py
-        ├── users.py
-        ├── events.py
-        ├── bets.py
-        └── odds.py
+# Backend
+
+Simple FastAPI backend using Firestore.
+
+## Setup
+
+Create a `.env` file based on `.env.sample` and provide `FIREBASE_PROJECT_ID` and `GOOGLE_APPLICATION_CREDENTIALS` pointing to your service account JSON file.
+
+Install dependencies and run locally:
+
+```bash
+pip install -r requirements.txt  # or use `uv pip install -r pyproject.toml`
+uvicorn src.main:app --reload
+```
+
+## Authentication
+
+Firebase Authentication is used to secure API endpoints. Provide a service
+account JSON file in `GOOGLE_APPLICATION_CREDENTIALS` and set
+`FIREBASE_PROJECT_ID` in your environment. Clients should authenticate with
+Firebase and send the ID token in the `Authorization` header when calling the
+API.
+
+The API exposes CRUD operations for users, events, clubs, bets and odds. Bets
+can be matched by posting to `/bets/{bet_id}/match` with the opponent user id.
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,7 @@
+fastapi>=0.115.12
+firebase-admin>=6.9.0
+google-cloud-firestore>=2.21.0
+passlib[bcrypt]>=1.7.4
+python-dotenv>=1.1.0
+python-jose[cryptography]>=3.5.0
+uvicorn>=0.34.3

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -1,0 +1,15 @@
+import os
+from functools import lru_cache
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+class Settings:
+    PROJECT_ID: str = os.getenv("FIREBASE_PROJECT_ID", "")
+    GOOGLE_APPLICATION_CREDENTIALS: str = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()

--- a/backend/src/db.py
+++ b/backend/src/db.py
@@ -1,0 +1,13 @@
+from google.cloud import firestore
+from firebase_admin import credentials, initialize_app
+from .config import get_settings
+
+_settings = get_settings()
+
+if _settings.GOOGLE_APPLICATION_CREDENTIALS:
+    cred = credentials.Certificate(_settings.GOOGLE_APPLICATION_CREDENTIALS)
+    initialize_app(cred)
+else:
+    initialize_app()
+
+client = firestore.Client(project=_settings.PROJECT_ID)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,0 +1,15 @@
+from fastapi import FastAPI
+from .routes import users, events, clubs, bets, odds
+
+app = FastAPI(title="SVM Betting API")
+
+app.include_router(users.router, prefix="/users", tags=["users"])
+app.include_router(events.router, prefix="/events", tags=["events"])
+app.include_router(clubs.router, prefix="/clubs", tags=["clubs"])
+app.include_router(bets.router, prefix="/bets", tags=["bets"])
+app.include_router(odds.router, prefix="/odds", tags=["odds"])
+
+
+@app.get("/")
+async def root():
+    return {"message": "SVM Betting API"}

--- a/backend/src/routes/__init__.py
+++ b/backend/src/routes/__init__.py
@@ -1,0 +1,3 @@
+from . import users, events, clubs, bets, odds
+
+__all__ = ["users", "events", "clubs", "bets", "odds"]

--- a/backend/src/routes/bets.py
+++ b/backend/src/routes/bets.py
@@ -1,0 +1,53 @@
+from datetime import datetime, timezone
+from fastapi import APIRouter, HTTPException
+from fastapi import Body
+
+from ..services.firestore import FirestoreService
+from ..schemas.bet import Bet
+
+router = APIRouter()
+service = FirestoreService("bets")
+
+
+@router.get("/", response_model=list[Bet])
+async def list_bets():
+    return [Bet(**b) for b in service.list()]
+
+
+@router.post("/", response_model=str)
+async def create_bet(bet: Bet):
+    data = bet.model_dump(exclude={"id"})
+    if not data.get("placed_at"):
+        data["placed_at"] = datetime.now(timezone.utc)
+    return service.create(data)
+
+
+@router.get("/{bet_id}", response_model=Bet)
+async def get_bet(bet_id: str):
+    bet = service.get(bet_id)
+    if not bet:
+        raise HTTPException(status_code=404, detail="Bet not found")
+    return Bet(**bet)
+
+
+@router.put("/{bet_id}")
+async def update_bet(bet_id: str, bet: Bet):
+    data = bet.model_dump(exclude={"id"})
+    service.update(bet_id, data)
+    return {"id": bet_id}
+
+
+@router.delete("/{bet_id}")
+async def delete_bet(bet_id: str):
+    service.delete(bet_id)
+    return {"status": "deleted"}
+
+
+@router.post("/{bet_id}/match")
+async def match_bet(bet_id: str, opponent_id: str = Body(..., embed=True)):
+    """Accept a bet by specifying an opponent user id."""
+    bet = service.get(bet_id)
+    if not bet:
+        raise HTTPException(status_code=404, detail="Bet not found")
+    service.update(bet_id, {"opponent_id": opponent_id, "status": "matched"})
+    return {"id": bet_id, "status": "matched"}

--- a/backend/src/routes/clubs.py
+++ b/backend/src/routes/clubs.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, HTTPException
+
+from ..services.firestore import FirestoreService
+from ..schemas.club import Club
+
+router = APIRouter()
+service = FirestoreService("clubs")
+
+
+@router.get("/", response_model=list[Club])
+async def list_clubs():
+    return [Club(**c) for c in service.list()]
+
+
+@router.post("/", response_model=str)
+async def create_club(club: Club):
+    data = club.model_dump(exclude={"id"})
+    return service.create(data)
+
+
+@router.get("/{club_id}", response_model=Club)
+async def get_club(club_id: str):
+    club = service.get(club_id)
+    if not club:
+        raise HTTPException(status_code=404, detail="Club not found")
+    return Club(**club)
+
+
+@router.put("/{club_id}")
+async def update_club(club_id: str, club: Club):
+    data = club.model_dump(exclude={"id"})
+    service.update(club_id, data)
+    return {"id": club_id}
+
+
+@router.delete("/{club_id}")
+async def delete_club(club_id: str):
+    service.delete(club_id)
+    return {"status": "deleted"}

--- a/backend/src/routes/events.py
+++ b/backend/src/routes/events.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, HTTPException
+
+from ..services.firestore import FirestoreService
+from ..schemas.event import Event
+
+router = APIRouter()
+service = FirestoreService("events")
+
+
+@router.get("/", response_model=list[Event])
+async def list_events():
+    return [Event(**e) for e in service.list()]
+
+
+@router.post("/", response_model=str)
+async def create_event(event: Event):
+    data = event.model_dump(exclude={"id"})
+    return service.create(data)
+
+
+@router.get("/{event_id}", response_model=Event)
+async def get_event(event_id: str):
+    ev = service.get(event_id)
+    if not ev:
+        raise HTTPException(status_code=404, detail="Event not found")
+    return Event(**ev)
+
+
+@router.put("/{event_id}")
+async def update_event(event_id: str, event: Event):
+    data = event.model_dump(exclude={"id"})
+    service.update(event_id, data)
+    return {"id": event_id}
+
+
+@router.delete("/{event_id}")
+async def delete_event(event_id: str):
+    service.delete(event_id)
+    return {"status": "deleted"}

--- a/backend/src/routes/odds.py
+++ b/backend/src/routes/odds.py
@@ -1,0 +1,47 @@
+from fastapi import APIRouter, HTTPException
+
+from ..services.firestore import FirestoreService
+from ..schemas.odds import Odds
+
+router = APIRouter()
+service = FirestoreService("odds")
+
+
+@router.get("/", response_model=list[Odds])
+async def list_odds():
+    return [Odds(**o) for o in service.list()]
+
+
+@router.post("/", response_model=str)
+async def create_odds(odds: Odds):
+    data = odds.model_dump(exclude={"id"})
+    return service.create(data)
+
+
+@router.get("/{odds_id}", response_model=Odds)
+async def get_odds(odds_id: str):
+    o = service.get(odds_id)
+    if not o:
+        raise HTTPException(status_code=404, detail="Odds not found")
+    return Odds(**o)
+
+
+@router.put("/{odds_id}")
+async def update_odds(odds_id: str, odds: Odds):
+    data = odds.model_dump(exclude={"id"})
+    service.update(odds_id, data)
+    return {"id": odds_id}
+
+
+@router.delete("/{odds_id}")
+async def delete_odds(odds_id: str):
+    service.delete(odds_id)
+    return {"status": "deleted"}
+
+
+@router.get("/club/{club_id}", response_model=Odds)
+async def odds_for_club(club_id: str):
+    doc = service.get(club_id)
+    if not doc:
+        raise HTTPException(status_code=404, detail="Odds not found")
+    return Odds(**doc)

--- a/backend/src/routes/users.py
+++ b/backend/src/routes/users.py
@@ -1,0 +1,46 @@
+from fastapi import APIRouter, Depends, HTTPException
+
+from ..services.firestore import FirestoreService
+from ..services.auth import get_current_user, create_user_with_email
+from ..schemas.user import User
+
+router = APIRouter()
+service = FirestoreService("users")
+
+
+@router.get("/", response_model=list[User])
+async def list_users():
+    return [User(**u) for u in service.list()]
+
+
+@router.post("/", response_model=str)
+async def create_user(user: User, _=Depends(get_current_user)):
+    data = user.model_dump(exclude={"id"})
+    return service.create(data)
+
+
+@router.get("/{user_id}", response_model=User)
+async def get_user(user_id: str):
+    user = service.get(user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return User(**user)
+
+
+@router.put("/{user_id}")
+async def update_user(user_id: str, user: User, _=Depends(get_current_user)):
+    data = user.model_dump(exclude={"id"})
+    service.update(user_id, data)
+    return {"id": user_id}
+
+
+@router.delete("/{user_id}")
+async def delete_user(user_id: str, _=Depends(get_current_user)):
+    service.delete(user_id)
+    return {"status": "deleted"}
+
+
+@router.post("/signup", response_model=str)
+async def signup(email: str, password: str):
+    uid = create_user_with_email(email, password)
+    return uid

--- a/backend/src/schemas/bet.py
+++ b/backend/src/schemas/bet.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+from datetime import datetime
+
+
+class Bet(BaseModel):
+    id: str | None = None
+    user_id: str
+    event_id: str
+    club_picked: str
+    amount: float
+    odds: float
+    opponent_id: str | None = None
+    status: str = "pending"
+    placed_at: datetime | None = None

--- a/backend/src/schemas/club.py
+++ b/backend/src/schemas/club.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+class Club(BaseModel):
+    id: str | None = None
+    name: str
+    league: str | None = None
+    points: int | None = None

--- a/backend/src/schemas/event.py
+++ b/backend/src/schemas/event.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel
+from datetime import datetime
+from typing import List
+
+
+class Event(BaseModel):
+    id: str | None = None
+    name: str
+    venue: str
+    date: datetime
+    clubs: List[str]
+    status: str | None = None

--- a/backend/src/schemas/odds.py
+++ b/backend/src/schemas/odds.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+from typing import Dict
+
+
+class Odds(BaseModel):
+    id: str | None = None
+    odds_details: Dict[str, float]

--- a/backend/src/schemas/user.py
+++ b/backend/src/schemas/user.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+from datetime import datetime
+
+
+class User(BaseModel):
+    id: str | None = None
+    email: str
+    coins: int = 0
+    created_at: datetime | None = None

--- a/backend/src/services/auth.py
+++ b/backend/src/services/auth.py
@@ -1,0 +1,23 @@
+from firebase_admin import auth
+from fastapi import HTTPException, Depends
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+
+
+security = HTTPBearer()
+
+
+def create_user_with_email(email: str, password: str):
+    """Create a Firebase Auth user."""
+    try:
+        user = auth.create_user(email=email, password=password)
+        return user.uid
+    except Exception as exc:  # pragma: no cover - simple example
+        raise HTTPException(status_code=400, detail="Could not create user") from exc
+
+
+def get_current_user(token: HTTPAuthorizationCredentials = Depends(security)):
+    try:
+        decoded = auth.verify_id_token(token.credentials)
+        return decoded
+    except Exception as exc:  # pragma: no cover - simple example
+        raise HTTPException(status_code=401, detail="Invalid authentication") from exc

--- a/backend/src/services/firestore.py
+++ b/backend/src/services/firestore.py
@@ -1,0 +1,29 @@
+from typing import Any, Dict, List
+from google.cloud.firestore import Client
+
+from ..db import client
+
+
+class FirestoreService:
+    def __init__(self, collection: str, db: Client = client):
+        self.collection = db.collection(collection)
+
+    def list(self) -> List[Dict[str, Any]]:
+        return [{"id": doc.id, **doc.to_dict()} for doc in self.collection.stream()]
+
+    def get(self, doc_id: str) -> Dict[str, Any] | None:
+        doc = self.collection.document(doc_id).get()
+        if doc.exists:
+            return {"id": doc.id, **doc.to_dict()}
+        return None
+
+    def create(self, data: Dict[str, Any]) -> str:
+        doc_ref = self.collection.document()
+        doc_ref.set(data)
+        return doc_ref.id
+
+    def update(self, doc_id: str, data: Dict[str, Any]) -> None:
+        self.collection.document(doc_id).update(data)
+
+    def delete(self, doc_id: str) -> None:
+        self.collection.document(doc_id).delete()

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,7 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', '$IMAGE', './backend']
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '$IMAGE']
+images:
+  - '$IMAGE'

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SVM Betting App</title>
+  <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
+  <script type="module" src="https://www.gstatic.com/firebasejs/9.6.10/firebase-app.js"></script>
+  <script type="module" src="https://www.gstatic.com/firebasejs/9.6.10/firebase-auth.js"></script>
+</head>
+<body>
+    <div id="app">
+      <h1>{{ title }}</h1>
+
+      <div v-if="!user">
+        <input type="email" v-model="email" placeholder="email" />
+        <input type="password" v-model="password" placeholder="password" />
+        <button @click="login">Login</button>
+      </div>
+
+      <div v-else>
+        <p>Logged in as {{ user.email }}</p>
+        <div>
+          <label>Team:
+            <select v-model="selectedClub">
+              <option value="" disabled>Select team</option>
+              <option v-for="c in clubs" :key="c.id" :value="c.id">{{ c.name }}</option>
+            </select>
+          </label>
+        </div>
+        <div v-if="selectedClub">
+          <label>Opponent:
+            <select v-model="opponentClub">
+              <option value="" disabled>Select opponent</option>
+              <option v-for="c in opponentOptions" :key="c.id" :value="c.id">{{ c.name }} (odds: {{ odds[c.id] || 1 }})</option>
+            </select>
+          </label>
+        </div>
+        <div v-if="opponentClub">
+          <input type="number" v-model="amount" placeholder="Amount" />
+          <button @click="placeBet">Place Bet</button>
+        </div>
+        <ul>
+          <li v-for="u in users" :key="u.id">{{ u.email }} - Coins: {{ u.coins }}</li>
+        </ul>
+      </div>
+    </div>
+
+  <script type="module">
+    import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.6.10/firebase-app.js';
+    import { getAuth, signInWithEmailAndPassword, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/9.6.10/firebase-auth.js';
+
+    const firebaseConfig = {
+      apiKey: 'YOUR_API_KEY',
+      authDomain: 'YOUR_PROJECT.firebaseapp.com'
+    };
+
+    const fbApp = initializeApp(firebaseConfig);
+    const auth = getAuth(fbApp);
+
+    const { createApp, ref, onMounted, watch, computed } = Vue;
+    createApp({
+      setup() {
+        const title = ref('SVM Betting');
+        const users = ref([]);
+        const user = ref(null);
+        const email = ref('');
+        const password = ref('');
+        const clubs = ref([]);
+        const selectedClub = ref('');
+        const opponentClub = ref('');
+        const odds = ref({});
+        const amount = ref(0);
+        const token = ref('');
+
+        const login = async () => {
+          await signInWithEmailAndPassword(auth, email.value, password.value);
+        };
+
+        const fetchUsers = async (token) => {
+          const res = await fetch('/api/users', {
+            headers: { Authorization: `Bearer ${token}` }
+          });
+          users.value = await res.json();
+        };
+
+        const fetchClubs = async () => {
+          const res = await fetch('/api/clubs');
+          clubs.value = await res.json();
+        };
+
+        const fetchOdds = async (clubId) => {
+          if (!clubId) return;
+          const res = await fetch(`/api/odds/club/${clubId}`);
+          const data = await res.json();
+          odds.value = data.odds_details || {};
+        };
+
+        const placeBet = async () => {
+          if (!token.value) return;
+          const res = await fetch('/api/bets', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${token.value}`
+            },
+            body: JSON.stringify({
+              user_id: user.value.uid,
+              event_id: 'default',
+              club_picked: selectedClub.value,
+              amount: Number(amount.value),
+              odds: odds.value[opponentClub.value] || 1
+            })
+          });
+          await res.json();
+        };
+
+        onMounted(() => {
+          onAuthStateChanged(auth, async (u) => {
+            user.value = u;
+            users.value = [];
+            if (u) {
+              token.value = await u.getIdToken();
+              await fetchUsers(token.value);
+              await fetchClubs();
+            } else {
+              token.value = '';
+            }
+          });
+        });
+
+        watch(selectedClub, async (val) => {
+          opponentClub.value = '';
+          odds.value = {};
+          await fetchOdds(val);
+        });
+
+        const opponentOptions = computed(() => clubs.value.filter(c => c.id !== selectedClub.value));
+        return { title, users, user, email, password, login, clubs, selectedClub, opponentClub, amount, odds, opponentOptions, placeBet };
+      }
+    }).mount('#app');
+  </script>
+</body>
+</html>

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,36 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+resource "google_service_account" "backend" {
+  account_id   = "backend-service"
+  display_name = "Backend Service Account"
+}
+
+resource "google_cloud_run_service" "backend" {
+  name     = "svm-backend"
+  location = var.region
+
+  template {
+    spec {
+      service_account_name = google_service_account.backend.email
+      containers {
+        image = var.image
+      }
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+}
+
+resource "google_project_service" "run" {
+  service = "run.googleapis.com"
+}
+
+resource "google_project_service" "firestore" {
+  service = "firestore.googleapis.com"
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,4 @@
+output "cloud_run_url" {
+  description = "URL of the deployed Cloud Run service"
+  value       = google_cloud_run_service.backend.status[0].url
+}

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -1,0 +1,3 @@
+project_id = "your-gcp-project"
+region     = "us-central1"
+image      = "gcr.io/your-gcp-project/backend:latest"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,15 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "image" {
+  description = "Container image for Cloud Run"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- extend Firestore service with update/delete
- expose CRUD routes for all entities
- add bet matching endpoint and opponent field
- introduce simple club schema
- improve Vue frontend to place bets against other clubs
- tweak docs with new instructions

## Testing
- `python3 -m py_compile backend/src/**/*.py`
- `terraform fmt -check infra/*.tf`
- `terraform init -backend=false` *(fails: could not connect to registry.terraform.io)*

------
https://chatgpt.com/codex/tasks/task_e_684fa23231b0832b94fbd06343fe0f1c