### PR TITLE
Implement Vue front‑end

### DIFF
--- a/frontend/colors.js
+++ b/frontend/colors.js
@@ -1,0 +1,60 @@
+// colors.js
+
+const clubColorClasses = {
+    "LCZ": 'team-color-lcz',
+    "STB": 'team-color-stb',
+    "LG Züri +": 'team-color-lgzuri',
+    "LG Basel Regio": 'team-color-lgregio',
+    "LC Schaffhausen": 'team-color-lcs',
+    "Stade Gèneve": 'team-color-stadeg',
+    "COA Valais Romand": 'team-color-coa',
+    "LG Thun": 'team-color-lgt',
+    "LV Winterthur": 'team-color-lvw',
+    "LG LZO": 'team-color-lglzo',
+    "BTV Aarau": 'team-color-btva',
+    "LG Oberthurgau": 'team-color-lgot',
+    "COA LR": "team-color-coalr",
+    "TVL": "team-color-tvl",
+    "LC Brühl LA":"team-color-lcbla",
+    "LG NS Luzern":"team-color-lgnslu",
+    "FSG Alle": "team-color-fsga",
+    "TV Wohlen": "team-color-tvw",
+    "LC Frauenfeld": "team-color-lcf",
+    "LGKE": "team-color-lgke",
+};
+
+// Podium color classes
+const podiumColorClasses = {
+    gold: 'podium-color-gold',
+    silver: 'podium-color-silver',
+    bronze: 'podium-color-bronze'
+};
+
+// Function to get the appropriate colors
+function getBarColor(index) {
+    if (index === 0) return podiumColorClasses.gold; // Gold
+    if (index === 1) return podiumColorClasses.silver; // Silver
+    if (index === 2) return podiumColorClasses.bronze; // Bronze
+
+    const club = sortedClubs[index];
+    return clubColorClasses[club]; // Return the CSS class for the club color
+}
+
+// Function to create the team color overview dynamically
+function createTeamColorOverview(clubNames, containerId) {
+    const container = document.getElementById(containerId);
+    clubNames.forEach(club => {
+        const listItem = document.createElement('li');
+        listItem.className = 'team-color-item';
+        
+        const colorBox = document.createElement('span');
+        colorBox.className = `team-color-box ${clubColorClasses[club]}`; // Use the CSS class for background color
+        listItem.appendChild(colorBox);
+        
+        const label = document.createElement('span');
+        label.textContent = ` ${club}`;
+        listItem.appendChild(label);
+
+        container.appendChild(listItem);
+    });
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,144 +1,235 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>SVM Betting App</title>
-  <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SVM Betting</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <script src="https://unpkg.com/vue@3"></script>
+  <script src="https://unpkg.com/vue-router@4"></script>
   <script type="module" src="https://www.gstatic.com/firebasejs/9.6.10/firebase-app.js"></script>
   <script type="module" src="https://www.gstatic.com/firebasejs/9.6.10/firebase-auth.js"></script>
 </head>
 <body>
-    <div id="app">
-      <h1>{{ title }}</h1>
-
-      <div v-if="!user">
-        <input type="email" v-model="email" placeholder="email" />
-        <input type="password" v-model="password" placeholder="password" />
-        <button @click="login">Login</button>
-      </div>
-
-      <div v-else>
-        <p>Logged in as {{ user.email }}</p>
-        <div>
-          <label>Team:
-            <select v-model="selectedClub">
-              <option value="" disabled>Select team</option>
-              <option v-for="c in clubs" :key="c.id" :value="c.id">{{ c.name }}</option>
-            </select>
-          </label>
-        </div>
-        <div v-if="selectedClub">
-          <label>Opponent:
-            <select v-model="opponentClub">
-              <option value="" disabled>Select opponent</option>
-              <option v-for="c in opponentOptions" :key="c.id" :value="c.id">{{ c.name }} (odds: {{ odds[c.id] || 1 }})</option>
-            </select>
-          </label>
-        </div>
-        <div v-if="opponentClub">
-          <input type="number" v-model="amount" placeholder="Amount" />
-          <button @click="placeBet">Place Bet</button>
-        </div>
-        <ul>
-          <li v-for="u in users" :key="u.id">{{ u.email }} - Coins: {{ u.coins }}</li>
+<div id="app">
+  <nav class="navbar navbar-expand-lg navbar-light bg-light">
+    <div class="container-fluid">
+      <a class="navbar-brand" href="#">SVM</a>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+          <li class="nav-item"><router-link class="nav-link" to="/">Home</router-link></li>
+          <li class="nav-item"><router-link class="nav-link" to="/projections">Projections</router-link></li>
+          <li class="nav-item" v-if="user"><router-link class="nav-link" to="/bet">Bet</router-link></li>
+          <li class="nav-item" v-if="user"><router-link class="nav-link" to="/transactions">Transactions</router-link></li>
+          <li class="nav-item"><router-link class="nav-link" to="/ranking">Ranking</router-link></li>
         </ul>
+        <div class="d-flex">
+          <router-link v-if="!user" class="btn btn-primary me-2" to="/login">Login</router-link>
+          <button v-if="user" class="btn btn-secondary" @click="logout">Logout</button>
+        </div>
       </div>
     </div>
+  </nav>
+  <router-view></router-view>
+</div>
 
-  <script type="module">
-    import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.6.10/firebase-app.js';
-    import { getAuth, signInWithEmailAndPassword, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/9.6.10/firebase-auth.js';
+<script type="module">
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.6.10/firebase-app.js';
+import { getAuth, signInWithEmailAndPassword, createUserWithEmailAndPassword, onAuthStateChanged, signOut } from 'https://www.gstatic.com/firebasejs/9.6.10/firebase-auth.js';
 
-    const firebaseConfig = {
-      apiKey: 'YOUR_API_KEY',
-      authDomain: 'YOUR_PROJECT.firebaseapp.com'
-    };
+const firebaseConfig = { apiKey: 'YOUR_API_KEY', authDomain: 'YOUR_PROJECT.firebaseapp.com' };
+const fbApp = initializeApp(firebaseConfig);
+const auth = getAuth(fbApp);
 
-    const fbApp = initializeApp(firebaseConfig);
-    const auth = getAuth(fbApp);
+const Landing = { template: `<div class='container py-4'><h1 class='mb-4'>Welcome to SVM Betting</h1><p>Select a page from the navigation.</p></div>` };
 
-    const { createApp, ref, onMounted, watch, computed } = Vue;
-    createApp({
-      setup() {
-        const title = ref('SVM Betting');
-        const users = ref([]);
-        const user = ref(null);
-        const email = ref('');
-        const password = ref('');
-        const clubs = ref([]);
-        const selectedClub = ref('');
-        const opponentClub = ref('');
-        const odds = ref({});
-        const amount = ref(0);
-        const token = ref('');
+const Login = {
+  template: `
+    <div class='container py-4'><h2>Login</h2>
+      <div class='mb-3'><input v-model='email' type='email' class='form-control' placeholder='Email'></div>
+      <div class='mb-3'><input v-model='password' type='password' class='form-control' placeholder='Password'></div>
+      <button class='btn btn-primary' @click='submit'>Login</button>
+      <router-link to='/signup' class='btn btn-link'>Sign up</router-link>
+    </div>`,
+  setup(){
+    const email = Vue.ref('');
+    const password = Vue.ref('');
+    const router = VueRouter.useRouter();
+    async function submit(){
+      await signInWithEmailAndPassword(auth, email.value, password.value);
+      router.push('/');
+    }
+    return { email, password, submit };
+  }
+};
 
-        const login = async () => {
-          await signInWithEmailAndPassword(auth, email.value, password.value);
-        };
+const Signup = {
+  template: `
+    <div class='container py-4'><h2>Sign Up</h2>
+      <div class='mb-3'><input v-model='email' type='email' class='form-control' placeholder='Email'></div>
+      <div class='mb-3'><input v-model='password' type='password' class='form-control' placeholder='Password'></div>
+      <button class='btn btn-primary' @click='submit'>Create account</button>
+      <router-link to='/login' class='btn btn-link'>Back to login</router-link>
+    </div>`,
+  setup(){
+    const email = Vue.ref('');
+    const password = Vue.ref('');
+    const router = VueRouter.useRouter();
+    async function submit(){
+      await createUserWithEmailAndPassword(auth, email.value, password.value);
+      router.push('/');
+    }
+    return { email, password, submit };
+  }
+};
 
-        const fetchUsers = async (token) => {
-          const res = await fetch('/api/users', {
-            headers: { Authorization: `Bearer ${token}` }
-          });
-          users.value = await res.json();
-        };
+const Projections = { template: `<div class='container py-4'><iframe src='projections.html' class='w-100' style='height:80vh;border:none;'></iframe></div>` };
 
-        const fetchClubs = async () => {
-          const res = await fetch('/api/clubs');
-          clubs.value = await res.json();
-        };
+const BetPage = {
+  template: `
+    <div class='container py-4'>
+      <h2>Place Bet</h2>
+      <div class='mb-3'>
+        <label class='form-label'>Team</label>
+        <select v-model='selectedClub' class='form-select'>
+          <option value='' disabled>Select team</option>
+          <option v-for='c in clubs' :key='c.id' :value='c.id'>{{ c.name }}</option>
+        </select>
+      </div>
+      <div class='mb-3' v-if='selectedClub'>
+        <label class='form-label'>Opponent</label>
+        <select v-model='opponentClub' class='form-select'>
+          <option value='' disabled>Select opponent</option>
+          <option v-for='c in opponentOptions' :key='c.id' :value='c.id'>{{ c.name }} (odds: {{ odds[c.id] || 1 }})</option>
+        </select>
+      </div>
+      <div class='mb-3' v-if='opponentClub'>
+        <input type='number' v-model='amount' class='form-control' placeholder='Amount'>
+      </div>
+      <button class='btn btn-primary' v-if='opponentClub' @click='placeBet'>Bet</button>
+    </div>
+  `,
+  setup(){
+    const user = Vue.ref(null);
+    const token = Vue.ref('');
+    const clubs = Vue.ref([]);
+    const selectedClub = Vue.ref('');
+    const opponentClub = Vue.ref('');
+    const odds = Vue.ref({});
+    const amount = Vue.ref(0);
+    const opponentOptions = Vue.computed(()=>clubs.value.filter(c=>c.id !== selectedClub.value));
+    const router = VueRouter.useRouter();
 
-        const fetchOdds = async (clubId) => {
-          if (!clubId) return;
-          const res = await fetch(`/api/odds/club/${clubId}`);
-          const data = await res.json();
-          odds.value = data.odds_details || {};
-        };
+    async function fetchClubs(){
+      const res = await fetch('/api/clubs');
+      clubs.value = await res.json();
+    }
+    async function fetchOdds(clubId){
+      if(!clubId) return;
+      const res = await fetch('/api/odds/club/'+clubId);
+      const data = await res.json();
+      odds.value = data.odds_details || {};
+    }
+    async function placeBet(){
+      if(!token.value) return;
+      await fetch('/api/bets',{
+        method:'POST',
+        headers:{
+          'Content-Type':'application/json',
+          Authorization:`Bearer ${token.value}`
+        },
+        body: JSON.stringify({
+          user_id:user.value.uid,
+          event_id:'default',
+          club_picked:selectedClub.value,
+          amount:Number(amount.value),
+          odds:odds.value[opponentClub.value] || 1
+        })
+      });
+      router.push('/transactions');
+    }
+    Vue.onMounted(()=>{
+      onAuthStateChanged(auth, async(u)=>{
+        user.value = u;
+        if(u){
+          token.value = await u.getIdToken();
+          await fetchClubs();
+        }
+      });
+    });
+    Vue.watch(selectedClub, fetchOdds);
+    return { clubs, selectedClub, opponentClub, odds, amount, opponentOptions, placeBet };
+  }
+};
 
-        const placeBet = async () => {
-          if (!token.value) return;
-          const res = await fetch('/api/bets', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              Authorization: `Bearer ${token.value}`
-            },
-            body: JSON.stringify({
-              user_id: user.value.uid,
-              event_id: 'default',
-              club_picked: selectedClub.value,
-              amount: Number(amount.value),
-              odds: odds.value[opponentClub.value] || 1
-            })
-          });
-          await res.json();
-        };
+const Transactions = {
+  template: `
+    <div class='container py-4'>
+      <h2>Transactions</h2>
+      <ul class='list-group'>
+        <li v-for='b in bets' :key='b.id' class='list-group-item'>
+          {{ b.club_picked }} vs {{ b.opponent_id || '?' }} - {{ b.amount }} coins @ {{ b.odds }} ({{ b.status }})
+        </li>
+      </ul>
+    </div>`,
+  setup(){
+    const bets = Vue.ref([]);
+    const tokenRef = Vue.ref('');
+    Vue.onMounted(()=>{
+      onAuthStateChanged(auth, async(u)=>{
+        if(u){
+          tokenRef.value = await u.getIdToken();
+          const res = await fetch('/api/bets', {headers:{Authorization:`Bearer ${tokenRef.value}`}});
+          bets.value = await res.json();
+        }
+      });
+    });
+    return { bets };
+  }
+};
 
-        onMounted(() => {
-          onAuthStateChanged(auth, async (u) => {
-            user.value = u;
-            users.value = [];
-            if (u) {
-              token.value = await u.getIdToken();
-              await fetchUsers(token.value);
-              await fetchClubs();
-            } else {
-              token.value = '';
-            }
-          });
-        });
+const Ranking = {
+  template: `
+    <div class='container py-4'>
+      <h2>Ranking</h2>
+      <ul class='list-group'>
+        <li v-for='u in users' :key='u.id' class='list-group-item'>
+          {{ u.email }} - {{ u.coins }} coins
+        </li>
+      </ul>
+    </div>`,
+  setup(){
+    const users = Vue.ref([]);
+    Vue.onMounted(async()=>{
+      const res = await fetch('/api/users');
+      users.value = (await res.json()).sort((a,b)=> (b.coins||0)-(a.coins||0));
+    });
+    return { users };
+  }
+};
 
-        watch(selectedClub, async (val) => {
-          opponentClub.value = '';
-          odds.value = {};
-          await fetchOdds(val);
-        });
+const routes = [
+  { path:'/', component: Landing },
+  { path:'/login', component: Login },
+  { path:'/signup', component: Signup },
+  { path:'/projections', component: Projections },
+  { path:'/bet', component: BetPage },
+  { path:'/transactions', component: Transactions },
+  { path:'/ranking', component: Ranking }
+];
 
-        const opponentOptions = computed(() => clubs.value.filter(c => c.id !== selectedClub.value));
-        return { title, users, user, email, password, login, clubs, selectedClub, opponentClub, amount, odds, opponentOptions, placeBet };
-      }
-    }).mount('#app');
-  </script>
+const router = VueRouter.createRouter({ history: VueRouter.createWebHashHistory(), routes });
+
+const app = Vue.createApp({
+  setup(){
+    const user = Vue.ref(null);
+    onAuthStateChanged(auth, u=> user.value=u);
+    function logout(){ signOut(auth); }
+    return { user, logout };
+  }
+});
+app.use(router);
+app.mount('#app');
+</script>
 </body>
 </html>

--- a/frontend/projections.html
+++ b/frontend/projections.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <!-- Existing head content -->
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Projektion</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="colors.js"></script>
+</head>
+<body class="bg-light">
+
+    <div class="container my-4">
+        <!-- Navigation Buttons -->
+        <div class="row justify-content-center mb-4">
+
+            <div class="col-md-3 text-center mb-3 mb-md-0">
+                <button id="switchLeagueBtn" class="btn btn-success btn-lg w-100"></button>
+            </div>
+        </div>
+
+        <div class="row justify-content-center mb-4">
+            <!-- Back to Index Button -->
+            <div class="col-md-3 text-center mb-3 mb-md-0">
+                <a href="index.html" class="btn btn-secondary btn-lg w-100">Zurück zum Zeitplan</a>
+            </div>
+
+            <!-- Switch Gender Button -->
+            <div class="col-md-3 text-center">
+                <button id="switchGenderBtn" class="btn btn-primary btn-lg w-100"></button>
+            </div>
+        </div>
+
+        <h1 class="text-center mb-4" id="pageTitle">Projektion & Resultate</h1>
+
+        <!-- Hidden input to pass the sheet name -->
+        <input type="hidden" id="sheetName" value="">
+
+        <!-- Dropdown to select discipline -->
+        <div class="row justify-content-center mb-4">
+            <div class="col-md-4">
+                <select id="disziplinSelect" class="form-select">
+                    <option value="">Gesamtübersicht</option>
+                </select>
+            </div>
+        </div>
+
+        <!-- Container for the chart -->
+        <div id="charts-container" class="mt-4"></div>
+    </div>
+
+    <!-- Include your scripts -->
+    <script src="script.js"></script>
+
+    <script>
+        // Function to get a cookie by name
+        function getCookie(name) {
+            let cookieArr = document.cookie.split(";");
+            for (let i = 0; i < cookieArr.length; i++) {
+                let cookiePair = cookieArr[i].split("=");
+                if (name === cookiePair[0].trim()) {
+                    return decodeURIComponent(cookiePair[1]);
+                }
+            }
+            return null;
+        }
+
+        // Function to set a cookie by name
+        function setCookie(name, value) {
+            document.cookie = `${name}=${value}; path=/`;
+        }
+
+        // Set the hidden input value, update the page title, and handle button functionality
+        document.addEventListener('DOMContentLoaded', () => {
+            let sheetName = getCookie('sheetName');
+            if (!sheetName) {
+                sheetName = 'men'; // Default to 'men' if no cookie is set
+                setCookie('sheetName', sheetName);
+            }
+
+            // Parse the sheetName to get gender and league
+            let gender = '';
+            let league = '';
+
+            if (sheetName.endsWith('_nlb')) {
+                league = 'nlb';
+                gender = sheetName.slice(0, -4); // Remove '_nlb' from sheetName
+            } else {
+                league = 'nla';
+                gender = sheetName;
+            }
+
+            // Update the hidden input value
+            document.getElementById('sheetName').value = sheetName;
+
+            // Update the page title
+            const leagueText = league.toUpperCase();
+            const genderText = gender === 'men' ? 'Männer' : 'Frauen';
+            document.getElementById('pageTitle').textContent = `Projektion SVM ${genderText} 2024 ${leagueText}`;
+
+            // Set the switch league button text and functionality
+            const switchLeagueBtn = document.getElementById('switchLeagueBtn');
+            switchLeagueBtn.textContent = league === 'nla' ? "Zur NLB" : "Zur NLA";
+            switchLeagueBtn.onclick = () => {
+                const newLeague = league === 'nla' ? 'nlb' : 'nla';
+                const newSheetName = newLeague === 'nlb' ? `${gender}_nlb` : gender;
+                setCookie('sheetName', newSheetName);
+                // Reload the page to apply changes
+                window.location.replace(window.location.pathname + '?t=' + new Date().getTime());
+            };
+
+            // Set the switch gender button text and functionality
+            const switchGenderBtn = document.getElementById('switchGenderBtn');
+            switchGenderBtn.textContent = gender === 'men' ? "Zu den Frauen" : "Zu den Männer";
+            switchGenderBtn.onclick = () => {
+                const newGender = gender === 'men' ? 'women' : 'men';
+                const newSheetName = league === 'nlb' ? `${newGender}_nlb` : newGender;
+                setCookie('sheetName', newSheetName);
+                // Reload the page to apply changes
+                window.location.replace(window.location.pathname + '?t=' + new Date().getTime());
+            };
+
+            // Now that we have the sheetName, we can use it in script.js to load the correct data
+            loadProjections(sheetName);
+        });
+    </script>
+</body>
+</html>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,0 +1,282 @@
+// Global variable to hold data
+let sheetData = [];
+
+function loadProjections(sheetName) {
+    const apiUrl = getApiUrl(sheetName);
+
+    fetch(apiUrl)
+        .then(response => response.json())
+        .then(data => {
+            // Process and display the data
+            processProjectionData(data);
+        })
+        .catch(error => console.error('Error fetching projection data:', error));
+}
+
+// Function to construct the API URL
+function getApiUrl(sheetName) {
+    const sheetId = '1KRsABdUN_udlAde7TE5aIrYHQ9-2HbnHwlHQTrN-R4E';
+    const apiKey = 'AIzaSyCQtpGO-z7Nh2bzQXMT4PIs3qviIqNeVIo';
+    return `https://sheets.googleapis.com/v4/spreadsheets/${sheetId}/values/${sheetName}?key=${apiKey}`;
+}
+
+// Function to process and display the data
+function processProjectionData(data) {
+    // Save the data to the global variable
+    sheetData = data.values; // Assuming data.values contains the array of arrays
+
+    // Populate the discipline select dropdown
+    populateDisziplinSelect(sheetData);
+
+    // Render the overall standings initially
+    renderOverallStandings(sheetData);
+}
+
+// Populate Disziplin dropdown
+function populateDisziplinSelect(data) {
+    const disziplinSelect = document.getElementById('disziplinSelect');
+
+    // Clear any existing options except the first one
+    disziplinSelect.options.length = 1; // Keep the "Gesamtübersicht" option
+
+    const disciplines = [...new Set(data.slice(1).map(row => row[1]).filter(d => d))]; // Get unique disciplines, filtering out any empty values
+
+    disciplines.forEach(discipline => {
+        const option = document.createElement('option');
+        option.value = discipline;
+        option.text = discipline;
+        disziplinSelect.appendChild(option);
+    });
+
+    // Add event listener for selection change
+    disziplinSelect.addEventListener('change', function() {
+        const selectedDisziplin = this.value;
+        if (selectedDisziplin) {
+            renderChartForDisziplin(selectedDisziplin, sheetData);
+        } else {
+            renderOverallStandings(sheetData);  // Render overall standings if no discipline is selected
+        }
+    });
+}
+
+// Function to adjust chart configuration for small screens
+function getChartOptions() {
+    const isSmallScreen = window.innerWidth < 768;
+
+    return {
+        indexAxis: 'y', // Horizontal bar chart
+        responsive: true,
+        maintainAspectRatio: false,
+        aspectRatio: isSmallScreen ? 1.5 : 2.5, // Adjust aspect ratio for small screens
+        scales: {
+            x: {
+                beginAtZero: true,
+                stacked: true // Stack the "Definitiv" and "Projektion" bars
+            },
+            y: {
+                stacked: true // "Definitiv" and "Projektion" bars are stacked
+            }
+        },
+        plugins: {
+            legend: {
+                display: true // Show the legend to differentiate between Definitiv and Projektion
+            },
+            tooltip: {
+                callbacks: {
+                    label: function(context) {
+                        const datasetIndex = context.datasetIndex;
+                        const value = context.raw;
+
+                        if (datasetIndex === 0) {
+                            return `Definitiv: ${value}`;
+                        } else if (datasetIndex === 1) {
+                            return `Projektion: ${value}`;
+                        }
+                    }
+                }
+            },
+            title: {
+                display: true,
+                text: 'Aktueller Stand',
+                font: {
+                    size: isSmallScreen ? 12 : 16 // Adjust font size for small screens
+                }
+            }
+        }
+    };
+}
+
+// Set canvas height based on screen size
+function setCanvasHeight(chartCanvas) {
+    const isSmallScreen = window.innerWidth < 768;
+    chartCanvas.height = isSmallScreen ? 600 : 1000;
+}
+
+// Render Overall Standings
+function renderOverallStandings(data) {
+    const headers = data[0];
+    const clubs = Array.from(new Set(headers.slice(3))); // Extract unique club names
+    const clubData = {};
+
+    // Initialize club data structure
+    clubs.forEach(club => {
+        clubData[club] = { projection: 0, definitive: 0 };
+    });
+
+    data.slice(1).forEach(row => {
+        const status = row[2]; // Status (Projektion or Definitiv)
+        clubs.forEach((club, index) => {
+            const points1 = parseInt(row[index * 2 + 3] || 0);
+            const points2 = parseInt(row[index * 2 + 4] || 0);
+            if (status === "Projektion") {
+                clubData[club].projection += points1 + points2;
+            } else if (status === "Definitiv") {
+                clubData[club].definitive += points1 + points2;
+            }
+        });
+    });
+
+    // Sort clubs by total points (definitive + projection)
+    const sortedClubs = Object.keys(clubData).sort((a, b) => {
+        const totalA = clubData[a].projection + clubData[a].definitive;
+        const totalB = clubData[b].projection + clubData[b].definitive;
+        return totalB - totalA;
+    });
+
+    // Prepare data for Chart.js
+    const definitiveData = sortedClubs.map(club => clubData[club].definitive);
+    const projectionData = sortedClubs.map(club => clubData[club].projection);
+
+    // Clear previous chart
+    document.getElementById('charts-container').innerHTML = '';
+    const chartCanvas = document.createElement('canvas');
+    document.getElementById('charts-container').appendChild(chartCanvas);
+
+    setCanvasHeight(chartCanvas);
+
+    const ctx = chartCanvas.getContext('2d');
+
+    new Chart(ctx, {
+        type: 'bar',
+        data: {
+            labels: sortedClubs, // Each club appears once
+            datasets: [
+                {
+                    label: 'Definitiv',
+                    data: definitiveData, // Data for the stacked bar (Definitiv)
+                    backgroundColor: sortedClubs.map((club) => {
+                        return adjustColorBrightness(clubColorClasses[club], -0.1);
+                    }) // Base color for definitive
+                },
+                {
+                    label: 'Projektion',
+                    data: projectionData, // Data for the stacked bar (Projektion)
+                    backgroundColor: sortedClubs.map((club) => {
+                        return adjustColorBrightness(clubColorClasses[club], 0.1);
+                    }) // Base color for projection
+                }
+            ]
+        },
+        options: getChartOptions()
+    });
+}
+
+// Render chart based on selected Disziplin
+function renderChartForDisziplin(discipline, data) {
+    const filteredRows = data.slice(1).filter(row => row[1] === discipline);
+    const headers = data[0];
+    const clubs = Array.from(new Set(headers.slice(3))); // Extract unique club names
+
+    const clubData = {};
+
+    // Initialize club data structure
+    clubs.forEach(club => {
+        clubData[club] = { athlete1: 0, athlete2: 0 };
+    });
+
+    let status = "Projektion";  // Default to Projektion
+
+    filteredRows.forEach(row => {
+        status = row[2];  // Update status based on data, assuming it's consistent across the discipline
+        clubs.forEach((club, index) => {
+            const points1 = parseInt(row[index * 2 + 3] || 0);
+            const points2 = parseInt(row[index * 2 + 4] || 0);
+            clubData[club].athlete1 += points1;
+            clubData[club].athlete2 += points2;
+        });
+    });
+
+    // Sort clubs by total points (athlete1 + athlete2)
+    const sortedClubs = Object.keys(clubData).sort((a, b) => {
+        const totalA = clubData[a].athlete1 + clubData[a].athlete2;
+        const totalB = clubData[b].athlete1 + clubData[b].athlete2;
+        return totalB - totalA;
+    });
+
+    // Prepare data for Chart.js
+    const athlete1Data = sortedClubs.map(club => clubData[club].athlete1);
+    const athlete2Data = sortedClubs.map(club => clubData[club].athlete2);
+
+    // Clear previous chart
+    document.getElementById('charts-container').innerHTML = '';
+    const chartCanvas = document.createElement('canvas');
+    document.getElementById('charts-container').appendChild(chartCanvas);
+
+    setCanvasHeight(chartCanvas);
+
+    const ctx = chartCanvas.getContext('2d');
+
+    new Chart(ctx, {
+        type: 'bar',
+        data: {
+            labels: sortedClubs, // Each club appears once
+            datasets: [
+                {
+                    label: 'Athlet 1',
+                    data: athlete1Data, // Data for the first athlete
+                    backgroundColor: sortedClubs.map((club) => {
+                        return adjustColorBrightness(clubColorClasses[club], -0.1);
+                    }) // Base color for Athlete 1
+                },
+                {
+                    label: 'Athlet 2',
+                    data: athlete2Data, // Data for the second athlete
+                    backgroundColor: sortedClubs.map((club) => {
+                        return adjustColorBrightness(clubColorClasses[club], 0.1);
+                    }) // Base color for Athlete 2
+                }
+            ]
+        },
+        options: {
+            ...getChartOptions(),
+            plugins: {
+                ...getChartOptions().plugins,
+                title: {
+                    display: true,
+                    text: `${discipline} - ${status}`, // Display the discipline name and status as the title
+                    font: {
+                        size: window.innerWidth < 768 ? 12 : 16 // Adjust font size for small screens
+                    }
+                }
+            }
+        }
+    });
+}
+
+// Utility function to adjust color brightness based on CSS class names
+function adjustColorBrightness(colorClass, percent) {
+    const tempDiv = document.createElement('div');
+    tempDiv.style.display = 'none';
+    tempDiv.className = colorClass;
+    document.body.appendChild(tempDiv);
+
+    const color = window.getComputedStyle(tempDiv).backgroundColor;
+    const rgb = color.match(/\d+/g);
+
+    const r = Math.min(255, Math.max(0, parseInt(rgb[0]) + percent * 255));
+    const g = Math.min(255, Math.max(0, parseInt(rgb[1]) + percent * 255));
+    const b = Math.min(255, Math.max(0, parseInt(rgb[2]) + percent * 255));
+
+    document.body.removeChild(tempDiv);
+    return `rgb(${r},${g},${b})`;
+}

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,194 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+}
+
+h1 {
+    text-align: center;
+}
+
+#charts-container {
+    width: 100%;
+    margin: 0 auto;
+}
+
+
+label {
+    display: block;
+    text-align: center;
+    margin-bottom: 10px;
+}
+
+select {
+    display: block;
+    margin: 0 auto;
+    margin-bottom: 20px;
+    padding: 5px;
+}
+
+
+/* styles.css */
+
+/* Team Colors */
+.team-color-lcz {
+    background-color: rgb(1, 153, 218);
+}
+
+.team-color-stb {
+    background-color: rgb(45, 45, 45);
+}
+
+.team-color-lgzuri {
+    background-color: rgb(21, 45, 150);
+}
+
+.team-color-lgregio {
+    background-color: rgb(233, 233, 46);
+}
+
+.team-color-lcs {
+    background-color: rgb(156, 157, 159);
+}
+
+.team-color-stadeg {
+    background-color: rgb(248, 219, 30);
+}
+
+.team-color-coa {
+    background-color: rgb(2, 145, 169);
+}
+
+.team-color-lgt {
+    background-color: rgb(216, 35, 42);
+}
+
+.team-color-lvw {
+    background-color: rgb(225, 55, 43);
+}
+
+.team-color-lglzo {
+    background-color: rgb(19, 134, 236);
+}
+
+.team-color-btva {
+    background-color: rgb(198, 51, 35);
+}
+
+.team-color-lgot {
+    background-color: rgb(14, 168, 77);
+}
+
+.team-color-lgot {
+    background-color: rgb(14, 168, 77);
+}
+
+.team-color-coalr {
+    background-color: rgb(1, 54, 165);
+}
+
+.team-color-tvl {
+    background-color: rgb(180, 0, 36);
+}
+
+.team-color-lcbla {
+    background-color: rgb(91, 164, 98);
+}
+
+.team-color-lgnslu {
+    background-color: rgb(26, 128, 182);
+}
+
+.team-color-fsga {
+    background-color: rgb(182, 55, 66);
+}
+
+.team-color-tvw {
+    background-color: rgb(204, 0, 0);
+}
+
+.team-color-lcf {
+    background-color: rgb(230, 80, 0);
+}
+
+.team-color-lgke {
+    background-color: rgb(40, 51, 74);
+}
+
+/* Podium Colors */
+.podium-color-gold {
+    background-color: rgb(255, 215, 0);
+}
+
+.podium-color-silver {
+    background-color: rgb(192, 192, 192);
+}
+
+.podium-color-bronze {
+    background-color: rgb(205, 127, 50);
+}
+
+/* styles.css */
+
+/* Team Colors */
+.team-color-box {
+    width: 20px;
+    height: 20px;
+    display: inline-block;
+    margin-right: 10px;
+    border: 1px solid #000;
+}
+
+.team-color-item {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    margin-bottom: 5px;
+}
+
+/* Fix the header when scrolling */
+header {
+    position: sticky;
+    top: 0;
+    z-index: 1000;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+}
+
+/* Styling for the Erklärung section */
+.erklaerung {
+    background-color: #f8f9fa;
+    padding: 20px;
+    border-radius: 5px;
+    margin-top: 20px;
+}
+
+/* Styling for the footer */
+footer {
+    background-color: #343a40;
+    color: #fff;
+    padding: 10px 0;
+    text-align: center;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.footer-left {
+    flex: 1;
+    text-align: left;
+    padding-left: 20px;
+}
+
+.footer-right {
+    flex: 1;
+    text-align: right;
+    padding-right: 20px;
+}
+
+footer a {
+    color: #fff;
+    text-decoration: none;
+}
+
+footer a:hover {
+    text-decoration: underline;
+}

--- a/frontend/timetable.js
+++ b/frontend/timetable.js
@@ -1,0 +1,62 @@
+// Google Sheets API settings
+const sheetId = '1KRsABdUN_udlAde7TE5aIrYHQ9-2HbnHwlHQTrN-R4E';  
+const apiKey = 'AIzaSyCQtpGO-z7Nh2bzQXMT4PIs3qviIqNeVIo';    
+
+let sheetData = [];
+// script.js
+
+// timetable.js
+
+// Function to get the league from the cookie
+function getLeague() {
+    const value = `; ${document.cookie}`;
+    const parts = value.split(`; league=`);
+    if (parts.length === 2) return parts.pop().split(';').shift();
+    return 'nla'; // Default to NLA
+}
+
+// Get the current league
+const league = getLeague();
+
+// Update API URLs based on the league
+const sheetNameMen = league === 'nlb' ? 'men_nlb' : 'men';
+const sheetNameWomen = league === 'nlb' ? 'women_nlb' : 'women';
+
+const apiUrlMen = `https://sheets.googleapis.com/v4/spreadsheets/${sheetId}/values/${sheetNameMen}?key=${apiKey}`;
+const apiUrlWomen = `https://sheets.googleapis.com/v4/spreadsheets/${sheetId}/values/${sheetNameWomen}?key=${apiKey}`;
+
+// Fetch data from Google Sheets for the timetable
+function fetchTimetable(apiUrl, targetElementId) {
+    fetch(apiUrl)
+        .then(response => response.json())
+        .then(data => {
+            const sheetData = data.values;
+            populateTimetable(sheetData, targetElementId);
+        })
+        .catch(error => console.error('Error fetching data:', error));
+}
+
+// Populate the timetable on the landing page
+function populateTimetable(data, targetElementId) {
+    const timetableBody = document.getElementById(targetElementId);
+
+    data.slice(1).forEach(row => {
+        const time = row[0];
+        const discipline = row[1];
+        const status = row[2];
+
+        const rowElement = document.createElement('tr');
+        rowElement.innerHTML = `
+            <td>${time}</td>
+            <td>${discipline}</td>
+            <td>${status}</td>
+        `;
+        timetableBody.appendChild(rowElement);
+    });
+}
+
+// Call fetchTimetable for both men’s and women’s timetables when the page loads
+document.addEventListener('DOMContentLoaded', () => {
+    fetchTimetable(apiUrlMen, 'timetable-body-men');
+    fetchTimetable(apiUrlWomen, 'timetable-body-women');
+});


### PR DESCRIPTION
## Summary
- copy existing projection pages and assets into `frontend`
- replace `frontend/index.html` with Vue 3 SPA using Vue Router and Bootstrap
- provide login, signup, projections, betting, transaction and ranking pages

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm -v`


------
https://chatgpt.com/codex/tasks/task_e_68530985a2c8832b9a1bd6121d0cc19b